### PR TITLE
Provenance graph now supports nodes that users don't have permissions to

### DIFF
--- a/app/scripts/actions/projectActions.js
+++ b/app/scripts/actions/projectActions.js
@@ -290,7 +290,7 @@ ProjectActions.getProvenance.preEmit = function (id, kind, prevGraph) {
     })
 };
 
-ProjectActions.getWasGeneratedByNode.preEmit = function (id, prevGraph) {
+ProjectActions.getWasGeneratedByNode.preEmit = function (id, kind, prevGraph) {
     fetch(urlGen.routes.baseUrl + urlGen.routes.apiPrefix + 'search/provenance/was_generated_by', {
         method: 'post',
         headers: {

--- a/app/scripts/components/globalComponents/provenance.jsx
+++ b/app/scripts/components/globalComponents/provenance.jsx
@@ -33,6 +33,7 @@ import Help from 'material-ui/lib/svg-icons/action/help';
 class Provenance extends React.Component {
     /**
      * Creates a provenance graph using the Vis.js library
+     * Uses a network graph from Vis.js
      * Vis docs @ visjs.org/docs/network/
      */
 
@@ -159,68 +160,80 @@ class Provenance extends React.Component {
         this.state.network.on("select", (params) => {
             let nodeData = nodes.get(params.nodes[0]);
             let edgeData = edges.get(params.edges);
-            if(params.nodes.length > 0) this.setState({node: nodeData});
-            if(params.nodes.length === 0) this.setState({showDetails: false});
-            ProjectActions.selectNodesAndEdges(edgeData, nodeData);
+            if(!nodeData.length && nodeData.properties.hasOwnProperty('audit')) { // User has visibility to node
+                if (params.nodes.length > 0) this.setState({node: nodeData});
+                if (params.nodes.length === 0) this.setState({showDetails: false});
+                ProjectActions.selectNodesAndEdges(edgeData, nodeData);
+            }
         });
         this.state.network.on("doubleClick", (params) => { // Show more nodes on graph on double click event
-            hideButtonsOnDblClk();
-            let prevGraph = {nodes: this.props.provNodes, edges: this.props.provEdges};
-            if(params.nodes.length > 0) {
-                let id = this.state.node.properties.current_version ? this.state.node.properties.current_version.id : this.state.node.properties.id;
-                let kind = this.state.node.properties.kind === 'dds-activity' ? 'dds-activity' : 'dds-file-version';
-                ProjectActions.getProvenance(id, kind, prevGraph);
+            let nodeData = nodes.get(params.nodes[0]);
+            if(!nodeData.length && nodeData.properties.hasOwnProperty('audit') && nodeData.properties.kind !== 'dds-activity') {
+                hideButtonsOnDblClk();
+                let prevGraph = {nodes: this.props.provNodes, edges: this.props.provEdges};
+                if (params.nodes.length > 0) {
+                    let id = this.state.node.properties.current_version ? this.state.node.properties.current_version.id : this.state.node.properties.id;
+                    let kind = this.state.node.properties.kind === 'dds-activity' ? 'dds-activity' : 'dds-file-version';
+                    ProjectActions.getWasGeneratedByNode(id, kind, prevGraph);
+                }
             }
         });
         this.state.network.on("click", (params) => {
             let nodeData = nodes.get(params.nodes[0]);
             let edgeData = edges.get(params.edges);
-            if(params.nodes.length > 0) {
-                if(!this.props.showProvDetails) ProjectActions.toggleProvNodeDetails();
-                if(nodeData.properties.kind !== 'dds-activity') {
-                    if(!this.props.removeFileFromProvBtn) ProjectActions.showRemoveFileFromProvBtn();
-                } else {
-                    if(nodeData.properties.audit.created_by.id !== this.props.currentUser.id && this.props.showProvCtrlBtns) {
-                        ProjectActions.showProvControlBtns();
-                    }
-                    if(nodeData.properties.audit.created_by.id === this.props.currentUser.id) {// If not creator then don't allow edit/delete activity
-                        if(!this.props.showProvCtrlBtns && nodeData.properties.kind === 'dds-activity') ProjectActions.showProvControlBtns();
-                        if(nodeData.properties.kind !== 'dds-activity' && this.props.showProvCtrlBtns) {
-                            this.state.network.unselectAll();
+            if(!nodeData.length && nodeData.properties.hasOwnProperty('audit')) { // User has visibility to node
+                if (params.nodes.length > 0) {
+                    if (!this.props.showProvDetails) ProjectActions.toggleProvNodeDetails();
+                    if (nodeData.properties.kind !== 'dds-activity') {
+                        if (!this.props.removeFileFromProvBtn) ProjectActions.showRemoveFileFromProvBtn();
+                    } else {
+                        if (nodeData.properties.audit.created_by.id !== this.props.currentUser.id && this.props.showProvCtrlBtns) {
                             ProjectActions.showProvControlBtns();
                         }
-                        if(nodeData.properties.kind !== 'dds-activity' && this.props.dltRelationsBtn) {
-                            this.state.network.unselectAll();
-                            ProjectActions.showDeleteRelationsBtn(edgeData, nodeData);
+                        if (nodeData.properties.audit.created_by.id === this.props.currentUser.id) {// If not creator then don't allow edit/delete activity
+                            if (!this.props.showProvCtrlBtns && nodeData.properties.kind === 'dds-activity') ProjectActions.showProvControlBtns();
+                            if (nodeData.properties.kind !== 'dds-activity' && this.props.showProvCtrlBtns) {
+                                this.state.network.unselectAll();
+                                ProjectActions.showProvControlBtns();
+                            }
+                            if (nodeData.properties.kind !== 'dds-activity' && this.props.dltRelationsBtn) {
+                                this.state.network.unselectAll();
+                                ProjectActions.showDeleteRelationsBtn(edgeData, nodeData);
+                            }
                         }
                     }
                 }
-            }
-            if(params.nodes.length === 0) {
-                this.state.network.unselectAll();
-                if(edgeData.length > 0) this.state.network.selectEdges([edgeData[0].id]);
-                if(this.props.removeFileFromProvBtn) ProjectActions.showRemoveFileFromProvBtn();
-                if(this.props.showProvCtrlBtns) ProjectActions.showProvControlBtns();
-            }
-            if(params.edges.length === 0 && this.props.dltRelationsBtn) {
-                if(this.props.showProvDetails) ProjectActions.toggleProvNodeDetails();
-                ProjectActions.showDeleteRelationsBtn(edgeData);
-                this.state.network.unselectAll();
-            }
-            if(params.edges.length === 0 && params.nodes.length === 0 && this.props.showProvDetails) ProjectActions.toggleProvNodeDetails();
-            if(edgeData.length > 0 && params.nodes.length < 1) {
-                if(this.props.showProvDetails) ProjectActions.toggleProvNodeDetails();
-                if(edgeData[0].type !== 'WasAssociatedWith' || edgeData[0].type !== 'WasAttributedTo') {
-                    if(edgeData.length > 0 && edgeData[0].properties.audit.created_by.id !== this.props.currentUser.id && this.props.dltRelationsBtn) {
-                        ProjectActions.showDeleteRelationsBtn(edgeData);
-                    }
-                    if(edgeData.length > 0 && edgeData[0].properties.audit.created_by.id === this.props.currentUser.id) {
-                        if(params.edges.length > 0 && params.nodes.length < 1) {
-                            if(!this.props.dltRelationsBtn) ProjectActions.showDeleteRelationsBtn(edgeData);
-                            if(this.props.showProvCtrlBtns && this.props.dltRelationsBtn) ProjectActions.showDeleteRelationsBtn(edgeData);
+                if (params.nodes.length === 0) {
+                    this.state.network.unselectAll();
+                    if (edgeData.length > 0) this.state.network.selectEdges([edgeData[0].id]);
+                    if (this.props.removeFileFromProvBtn) ProjectActions.showRemoveFileFromProvBtn();
+                    if (this.props.showProvCtrlBtns) ProjectActions.showProvControlBtns();
+                }
+                if (params.edges.length === 0 && this.props.dltRelationsBtn) {
+                    if (this.props.showProvDetails) ProjectActions.toggleProvNodeDetails();
+                    ProjectActions.showDeleteRelationsBtn(edgeData);
+                    this.state.network.unselectAll();
+                }
+                if (params.edges.length === 0 && params.nodes.length === 0 && this.props.showProvDetails) ProjectActions.toggleProvNodeDetails();
+                if (edgeData.length > 0 && params.nodes.length < 1) {
+                    if (this.props.showProvDetails) ProjectActions.toggleProvNodeDetails();
+                    if (edgeData[0].type !== 'WasAssociatedWith' || edgeData[0].type !== 'WasAttributedTo') {
+                        if (edgeData.length > 0 && edgeData[0].properties.audit.created_by.id !== this.props.currentUser.id && this.props.dltRelationsBtn) {
+                            ProjectActions.showDeleteRelationsBtn(edgeData);
+                        }
+                        if (edgeData.length > 0 && edgeData[0].properties.audit.created_by.id === this.props.currentUser.id) {
+                            if (params.edges.length > 0 && params.nodes.length < 1) {
+                                if (!this.props.dltRelationsBtn) ProjectActions.showDeleteRelationsBtn(edgeData);
+                                if (this.props.showProvCtrlBtns && this.props.dltRelationsBtn) ProjectActions.showDeleteRelationsBtn(edgeData);
+                            }
                         }
                     }
                 }
+            } else {
+                this.state.network.unselectAll();
+                if (this.props.showProvDetails) ProjectActions.toggleProvNodeDetails();
+                if (this.props.showProvCtrlBtns) ProjectActions.showProvControlBtns();
+                if (this.props.dltRelationsBtn) ProjectActions.showDeleteRelationsBtn(edgeData, nodeData);
             }
         })
     }

--- a/app/scripts/graphConfig.js
+++ b/app/scripts/graphConfig.js
@@ -71,6 +71,18 @@ export const graphColors = {
             background: '#2196F3'
         }
     },
+    noPermissions: {
+        border: '#BDBDBD',
+        background: '#BDBDBD',
+        highlight: {
+            border: '#BDBDBD',
+            background: '#BDBDBD'
+        },
+        hover: {
+            border: '#BDBDBD',
+            background: '#BDBDBD'
+        }
+    },
     user: {
         border: '#64DD17',
         background: '#64DD17',

--- a/app/scripts/stores/projectStore.js
+++ b/app/scripts/stores/projectStore.js
@@ -461,32 +461,44 @@ var ProjectStore = Reflux.createStore({
             }
         });
         this.provNodes = nodes.map((node) => {
-            if (node.properties.kind === 'dds-activity') {
-                return {
-                    id: node.id,
-                    label: 'Activity: \n'+node.properties.name,
-                    labels: node.labels.toString(),
-                    properties: node.properties,
-                    shape: 'box',
-                    color: graphColors.activity,
-                    title: '<div style="margin: 10px; color: #616161"><span>'
-                    +'Name: '+node.properties.name + '</span><br/>' +
-                    '<span>'+'Created By: '+node.properties.audit.created_by.full_name+'</span><br/>' +
-                    '<span>'+'Started On: '+node.properties.started_on+'</span></div>'
+            if(node.properties.hasOwnProperty('audit')) {
+                if (node.properties.kind === 'dds-activity') {
+                    return {
+                        id: node.id,
+                        label: 'Activity: \n' + node.properties.name,
+                        labels: node.labels.toString(),
+                        properties: node.properties,
+                        shape: 'box',
+                        color: graphColors.activity,
+                        title: '<div style="margin: 10px; color: #616161"><span>'
+                        + 'Name: ' + node.properties.name + '</span><br/>' +
+                        '<span>' + 'Created By: ' + node.properties.audit.created_by.full_name + '</span><br/>' +
+                        '<span>' + 'Started On: ' + node.properties.started_on + '</span></div>'
+                    }
                 }
-            }
-            if(node.properties.kind === 'dds-file-version') {
-                let label = node.properties.label !== null ? node.properties.label : "";
+                if (node.properties.kind === 'dds-file-version') {
+                    let label = node.properties.label !== null ? node.properties.label : "";
+                    return {
+                        id: node.id,
+                        label: node.properties.file.name + '\nVersion: ' + node.properties.version,
+                        labels: node.labels.toString(),
+                        properties: node.properties,
+                        color: graphColors.fileVersion,
+                        title: '<div style="margin: 10px; color: #616161"><span>'
+                        + node.properties.file.name + '</span><br/><span>Version: '
+                        + node.properties.version + '</span><br/><span>'
+                        + label + '</span></div>'
+                    }
+                }
+            } else {
                 return {
                     id: node.id,
-                    label: node.properties.file.name + '\nVersion: ' + node.properties.version,
+                    label: node.properties.kind,
                     labels: node.labels.toString(),
                     properties: node.properties,
-                    color: graphColors.fileVersion,
+                    color: graphColors.noPermissions,
                     title: '<div style="margin: 10px; color: #616161"><span>'
-                    + node.properties.file.name + '</span><br/><span>Version: '
-                    + node.properties.version + '</span><br/><span>'
-                    + label + '</span></div>'
+                    + 'You do not have permission to view this file.' + '</span></div>'
                 }
             }
         });
@@ -948,7 +960,8 @@ var ProjectStore = Reflux.createStore({
         let err = error && error.message ? {msg: error.message, response: error.response.status} : null;
         if(error && error.response.status !== 404) {
             this.errorModals.push({
-                msg: error.message,
+                msg: error.response.status === 403 ? error.message + ': You don\'t have permissions to view or change' +
+                ' this resource' : error.message,
                 response: error.response.status,
                 ref: 'modal' + Math.floor(Math.random() * 10000)
             });
@@ -968,6 +981,7 @@ var ProjectStore = Reflux.createStore({
             }
         }
         this.trigger({
+            error: {},
             errorModals: this.errorModals
         })
     },


### PR DESCRIPTION
- Nodes that the user doesn't have permissions (visibility) to will show up in the graph as greyed out nodes and are restricted from user actions in the graph such as creating relations to the nodes or viewing details about them. No name is returned from neo4j so the nodes are simply labeled as "dds-file-version" and when the user hovers over them they see a message telling them that they don't have permissions to view the file. 
